### PR TITLE
fix: catch url param error

### DIFF
--- a/packages/sdk-react-provider/src/lib/provider.tsx
+++ b/packages/sdk-react-provider/src/lib/provider.tsx
@@ -58,6 +58,22 @@ export const MoneriumProvider = ({
   const [loadingAuth, setLoadingAuth] = useState(true);
 
   useEffect(() => {
+    // Handle error parameters from auth flow redirect
+    const urlParams = new URLSearchParams(window?.location?.search);
+    const error = urlParams?.get('error');
+    const errorDescription = urlParams?.get('error_description');
+
+    if (error) {
+      const errorMessage = errorDescription
+        ? `${error}: ${decodeURIComponent(errorDescription)}`
+        : error;
+      setError(new Error(errorMessage));
+      setLoadingAuth(false);
+      return;
+    }
+  }, []);
+
+  useEffect(() => {
     const connect = async () => {
       if (sdk) {
         try {


### PR DESCRIPTION
user reported on Discord:

https://discord.com/channels/1286150637452660798/1293171908082274427/1388409601053163632

LARGO — 2025-06-28, 06:44
Hey, I'm running into an issue with the Monerium SDK where the error state from useAuth() always stays null even when authorization fails.

Here's what's happening: when I call authorize() or siwe() and the auth fails on Monerium's side, the user gets redirected back to my app with error parameters in the URL like ?error=server_error&error_description=The+authorization+server+encountered+an+unexpected+condition.... However, the error state from the useAuth() hook doesn't get updated to reflect this failure - it just stays null.

This is causing a problem because my code checks if (!isAuthorized && !error) to trigger the auth flow, but since error is always null even after failed auth, this condition stays true and triggers the auth flow again, creating an infinite redirect loop.

Right now I have to manually check window.location.search for error parameters as a workaround, but the SDK should handle this automatically. Could you look into making sure the useAuth() hook properly captures authorization failures and reflects them in the error state? This would prevent the infinite loops and allow proper error handling in applications.