### PR TITLE
feat(kyc): rename profile state submitted to pending

### DIFF
--- a/apps/customer/app/(authorized)/profile/page.tsx
+++ b/apps/customer/app/(authorized)/profile/page.tsx
@@ -34,7 +34,7 @@ const profileStateColor = (
   switch (state) {
     case 'approved':
       return 'success';
-    case 'submitted':
+    case 'pending':
     case 'created':
       return 'info';
     case 'incomplete':

--- a/apps/developer/static/llms/whitelabel.txt
+++ b/apps/developer/static/llms/whitelabel.txt
@@ -322,7 +322,7 @@ Content-Type: application/json
 
 ### Profile states
 
-`created` -> `incomplete` -> `submitted` -> `approved` or `rejected`
+`created` -> `incomplete` -> `pending` -> `approved` or `rejected`
 
 Monitor via `profile.updated` webhook. The event payload includes the current `state`.
 

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -3726,7 +3726,7 @@ tags:
     x-displayName: Changelog
     description: |
       ### 2026-05-06:
-      * `ProfileState` and `SectionState`: renamed `submitted` to `pending`.
+      * [GET /profiles](#operation/profiles), [GET /profiles/{profile}](#operation/profile), [POST /profiles](#operation/create-profile), [GET /auth/context](#operation/auth-context), [Webhook profile.updated](#operation/webhook-profile-updated) - `ProfileState` and `SectionState`: renamed `submitted` to `pending`.
 
       ### 2026-04-29:
       * [PATCH /profiles/{profileId}/verifications](#operation/patch-profile-verifications) - Separated request schemas (`UpdatePersonalVerifications` and `UpdateCorporateVerifications`) from response schemas.

--- a/packages/openapi/openapi.yml
+++ b/packages/openapi/openapi.yml
@@ -828,7 +828,7 @@ paths:
 
         Monerium uses the supplied token to fetch data from the provider and updates the
         relevant sections. Each section that receives sufficient data transitions to
-        `submitted`; any that remain incomplete stay `incomplete`.
+        `pending`; any that remain incomplete stay `incomplete`.
       parameters:
         - $ref: '#/components/parameters/AcceptHeaderV2'
         - name: profile
@@ -3454,14 +3454,14 @@ components:
         The state of a profile section:
 
         * `incomplete`: The partner can still submit or update this section.
-        * `submitted`: All required information has been provided; awaiting review.
+        * `pending`: All required information has been provided; awaiting review.
         * `approved`: The section has been approved.
         * `rejected`: Final rejection; no resubmission possible.
       type: string
       example: incomplete
       enum:
         - incomplete
-        - submitted
+        - pending
         - approved
         - rejected
     ProfileSection:
@@ -3476,7 +3476,7 @@ components:
 
         * `created`: The profile has been created but no data has been submitted yet.
         * `incomplete`: One or more sections still require information. The partner can submit or update data.
-        * `submitted`: All required information has been provided and the profile is awaiting review. Further submissions are blocked until the state transitions to `approved`, `rejected`, or back to `incomplete`.
+        * `pending`: All required information has been provided and the profile is awaiting review. Further submissions are blocked until the state transitions to `approved`, `rejected`, or back to `incomplete`.
         * `approved`: The profile is active and all Monerium services are available.
         * `rejected`: Final rejection — the applicant details did not meet compliance requirements.
       type: string
@@ -3484,7 +3484,7 @@ components:
       enum:
         - created
         - incomplete
-        - submitted
+        - pending
         - approved
         - rejected
     ProfileKind:
@@ -3725,6 +3725,9 @@ tags:
   - name: changes
     x-displayName: Changelog
     description: |
+      ### 2026-05-06:
+      * `ProfileState` and `SectionState`: renamed `submitted` to `pending`.
+
       ### 2026-04-29:
       * [PATCH /profiles/{profileId}/verifications](#operation/patch-profile-verifications) - Separated request schemas (`UpdatePersonalVerifications` and `UpdateCorporateVerifications`) from response schemas.
       * `Profile` response schema now explicitly uses `oneOf` to return either a `ProfilePersonal` or `ProfileCorporate` structure based on the `kind`.

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -101,7 +101,7 @@ export type Permission = 'read' | 'write';
 export type ProfileState =
   | 'created'
   | 'incomplete'
-  | 'submitted'
+  | 'pending'
   | 'approved'
   | 'rejected';
 


### PR DESCRIPTION
## Summary
Renamed the profile and section state `submitted` to `pending` across the monorepo to better align with the asynchronous review process and improve naming consistency.

## Changes
- **OpenAPI**: Updated `ProfileState` and `SectionState` definitions and added a changelog entry in `packages/openapi/openapi.yml`.
- **SDK**: Updated `ProfileState` type in `packages/sdk/src/types.ts`.
- **Customer App**: Updated UI state logic in `apps/customer/app/(authorized)/profile/page.tsx`.
- **Docs**: Updated onboarding lifecycle documentation in `apps/developer/static/llms/whitelabel.txt`.