### PR TITLE
docs(whitelabel): remove example placeholder sumsub share token

### DIFF
--- a/apps/developer/docs/sumsub.mdx
+++ b/apps/developer/docs/sumsub.mdx
@@ -21,7 +21,7 @@ To enable KYC sharing, you need to add Monerium as a partner using our share tok
 4. Enter the **Share Token** (which is environment-agnostic and used for both Sandbox and Production):
 
 ```text
-sbx_eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJtb25lcml1bS5jb20iLCJqdGkiOiJzYW5kYm94LXNoYXJlLXRva2VuLWV4YW1wbGUiLCJjbGllbnROYW1lIjoiTW9uZXJpdW0ifQ.gibberishSignatureHereOnlyAnExampleTokenDoNotUseDirectly
+sbx_EXAMPLE_TOKEN
 ```
 
 ---

--- a/apps/developer/docs/sumsub.mdx
+++ b/apps/developer/docs/sumsub.mdx
@@ -18,11 +18,7 @@ To enable KYC sharing, you need to add Monerium as a partner using our share tok
 1. Log in to your **Sumsub Dashboard**.
 2. From the left sidebar, navigate to **Reusable Identity** ➔ **Partners** ➔ **Recipients**.
 3. Click on **Add Recipient**.
-4. Enter the **Share Token** (which is environment-agnostic and used for both Sandbox and Production):
-
-```text
-sbx_EXAMPLE_TOKEN
-```
+4. Enter your Monerium-provided partner share token.
 
 ---
 


### PR DESCRIPTION
It isn't very clear when glancing at the documentation that the token in the sumsub page is an example token, so we're removing it.